### PR TITLE
Implement undo/redo

### DIFF
--- a/src-tauri/src/editor.rs
+++ b/src-tauri/src/editor.rs
@@ -273,6 +273,7 @@ impl Editor {
     pub fn delete(&mut self) {
         if self.selection.is_some() {
             self.inner_delete_selection_content();
+            self.history.push(self.snapshot());
             return;
         }
 
@@ -282,11 +283,12 @@ impl Editor {
             i if i == self.sequence.len() => _ = self.sequence.pop_back(),
             i => _ = self.sequence.remove(i - 1),
         }
+
         if self.cursor_pos != 0 {
             self.sequence_dirty = true;
         }
-        self.inner_move_cursor(CursorMovement::By(-1), true);
 
+        self.inner_move_cursor(CursorMovement::By(-1), true);
         self.history.push(self.snapshot());
     }
 
@@ -307,13 +309,13 @@ impl Editor {
     pub fn move_cursor(&mut self, movement: CursorMovement) {
         self.inner_move_cursor(movement, true);
 
-        self.history.push(self.snapshot());
+        // self.history.push(self.snapshot());
     }
 
     pub fn move_selection(&mut self, movement: SelectionMovement) {
         self.inner_move_selection(movement);
 
-        self.history.push(self.snapshot());
+        // self.history.push(self.snapshot());
     }
 
     // TODO: This could be heavily optimized by keeping track of "dirty" coding regions

--- a/src-tauri/src/history.rs
+++ b/src-tauri/src/history.rs
@@ -1,0 +1,115 @@
+use std::collections::VecDeque;
+
+use plasmid::uni::IupacNucleotide;
+
+use crate::editor::Selection;
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct EditorSnapshot {
+    pub cursor_pos: usize,
+    pub selection: Option<Selection>,
+    pub sequence: Vec<IupacNucleotide>,
+}
+
+#[derive(Debug, Default)]
+pub struct EditorSnapshotHistory {
+    pub snapshots: VecDeque<EditorSnapshot>,
+    index: usize,
+}
+
+impl EditorSnapshotHistory {
+    pub fn clear(&mut self) {
+        self.snapshots.clear();
+        self.index = 0;
+    }
+
+    pub fn push(&mut self, snapshot: EditorSnapshot) {
+        if !self.snapshots.is_empty() && self.index < self.snapshots.len() - 1 {
+            self.snapshots.truncate(self.index);
+        }
+        self.snapshots.push_back(snapshot);
+        self.index = self.snapshots.len() - 1;
+    }
+
+    pub fn get_undo_snapshot(&mut self) -> Option<EditorSnapshot> {
+        if self.index > 0 {
+            self.index -= 1;
+            Some(self.snapshots[self.index].clone())
+        } else {
+            None
+        }
+    }
+
+    pub fn get_redo_snapshot(&mut self) -> Option<EditorSnapshot> {
+        if self.index < self.snapshots.len() {
+            self.index += 1;
+            let result = Some(self.snapshots[self.index].clone());
+            result
+        } else {
+            None
+        }
+    }
+
+    #[cfg(test)]
+    pub fn peek_undo_snapshot(&self) -> Option<&EditorSnapshot> {
+        if self.index > 0 {
+            Some(&self.snapshots[self.index - 1])
+        } else {
+            None
+        }
+    }
+
+    #[cfg(test)]
+    pub fn peek_redo_snapshot(&self) -> Option<&EditorSnapshot> {
+        if self.index < self.snapshots.len() {
+            Some(&self.snapshots[self.index + 1])
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EditorSnapshot, EditorSnapshotHistory};
+
+    #[test]
+    fn test_undo() {
+        let mut history = EditorSnapshotHistory::default();
+
+        history.push(EditorSnapshot::default());
+        assert_eq!(history.index, 0);
+        assert_eq!(history.peek_undo_snapshot(), None);
+
+        history.push(EditorSnapshot::default());
+        assert_eq!(history.index, 1);
+        assert_eq!(
+            history.peek_undo_snapshot(),
+            Some(&EditorSnapshot {
+                cursor_pos: 0,
+                selection: None,
+                sequence: vec![],
+            })
+        );
+
+        history.get_undo_snapshot().unwrap();
+        assert_eq!(history.index, 0);
+        assert_eq!(history.get_undo_snapshot(), None);
+    }
+
+    #[test]
+    fn test_redo() {
+        let mut history = EditorSnapshotHistory::default();
+
+        history.push(EditorSnapshot::default());
+        history.push(EditorSnapshot::default());
+        assert_eq!(history.index, 1);
+
+        history.get_undo_snapshot().unwrap();
+        assert_eq!(history.index, 0);
+        assert_eq!(history.peek_redo_snapshot(), Some(&EditorSnapshot::default()));
+
+        history.get_redo_snapshot().unwrap();
+        assert_eq!(history.index, 1);
+    }
+}

--- a/src-tauri/src/history.rs
+++ b/src-tauri/src/history.rs
@@ -41,7 +41,7 @@ impl EditorSnapshotHistory {
     }
 
     pub fn get_redo_snapshot(&mut self) -> Option<EditorSnapshot> {
-        if self.index < self.snapshots.len() {
+        if self.index < self.snapshots.len() - 1 {
             self.index += 1;
             let result = Some(self.snapshots[self.index].clone());
             result
@@ -61,7 +61,7 @@ impl EditorSnapshotHistory {
 
     #[cfg(test)]
     pub fn peek_redo_snapshot(&self) -> Option<&EditorSnapshot> {
-        if self.index < self.snapshots.len() {
+        if self.index < self.snapshots.len() - 1 {
             Some(&self.snapshots[self.index + 1])
         } else {
             None

--- a/src-tauri/src/history.rs
+++ b/src-tauri/src/history.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use plasmid::uni::IupacNucleotide;
+use plasmid::{traits::ToLetter, uni::IupacNucleotide};
 
 use crate::editor::Selection;
 
@@ -9,6 +9,21 @@ pub struct EditorSnapshot {
     pub cursor_pos: usize,
     pub selection: Option<Selection>,
     pub sequence: Vec<IupacNucleotide>,
+}
+
+impl std::fmt::Display for EditorSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "EditorSnapshot(cursor_pos: {}, selection: {:?}, sequence: {:?})",
+            self.cursor_pos,
+            self.selection,
+            self.sequence
+                .iter()
+                .map(|n| n.to_letter())
+                .collect::<String>()
+        )
+    }
 }
 
 #[derive(Debug, Default)]
@@ -24,9 +39,18 @@ impl EditorSnapshotHistory {
     }
 
     pub fn push(&mut self, snapshot: EditorSnapshot) {
-        if !self.snapshots.is_empty() && self.index < self.snapshots.len() - 1 {
-            self.snapshots.truncate(self.index);
+        // Truncate snapshots. Not sure whether this is a good idea or not..
+        if self.snapshots.len() >= 2 && self.index < self.snapshots.len().saturating_sub(1) {
+            self.snapshots.truncate(self.index + 1);
         }
+
+        // Disallow pushing the same snapshot twice
+        if let Some(last_snapshot) = self.snapshots.iter().last() {
+            if &snapshot == last_snapshot {
+                return;
+            }
+        }
+
         self.snapshots.push_back(snapshot);
         self.index = self.snapshots.len() - 1;
     }
@@ -75,21 +99,23 @@ mod tests {
 
     #[test]
     fn test_undo() {
+        use plasmid::uni::IupacNucleotide::*;
+
         let mut history = EditorSnapshotHistory::default();
 
         history.push(EditorSnapshot::default());
         assert_eq!(history.index, 0);
         assert_eq!(history.peek_undo_snapshot(), None);
 
-        history.push(EditorSnapshot::default());
+        history.push(EditorSnapshot {
+            cursor_pos: 3,
+            selection: None,
+            sequence: vec![A, T, G],
+        });
         assert_eq!(history.index, 1);
         assert_eq!(
             history.peek_undo_snapshot(),
-            Some(&EditorSnapshot {
-                cursor_pos: 0,
-                selection: None,
-                sequence: vec![],
-            })
+            Some(&EditorSnapshot::default())
         );
 
         history.get_undo_snapshot().unwrap();
@@ -99,17 +125,74 @@ mod tests {
 
     #[test]
     fn test_redo() {
+        use plasmid::uni::IupacNucleotide::*;
+
         let mut history = EditorSnapshotHistory::default();
 
         history.push(EditorSnapshot::default());
-        history.push(EditorSnapshot::default());
+        history.push(EditorSnapshot {
+            cursor_pos: 3,
+            selection: None,
+            sequence: vec![A, T, G],
+        });
         assert_eq!(history.index, 1);
 
         history.get_undo_snapshot().unwrap();
         assert_eq!(history.index, 0);
-        assert_eq!(history.peek_redo_snapshot(), Some(&EditorSnapshot::default()));
+        assert_eq!(
+            history.peek_redo_snapshot(),
+            Some(&EditorSnapshot {
+                cursor_pos: 3,
+                selection: None,
+                sequence: vec![A, T, G],
+            })
+        );
 
         history.get_redo_snapshot().unwrap();
         assert_eq!(history.index, 1);
+    }
+
+    #[test]
+    fn test_truncation() {
+        use plasmid::uni::IupacNucleotide::*;
+
+        let mut history = EditorSnapshotHistory::default();
+
+        history.push(EditorSnapshot::default());
+        history.push(EditorSnapshot {
+            cursor_pos: 4,
+            selection: None,
+            sequence: vec![A, T, G, C],
+        });
+        history.push(EditorSnapshot {
+            cursor_pos: 6,
+            selection: None,
+            sequence: vec![A, T, G, C, T, G],
+        });
+        history.get_undo_snapshot().unwrap();
+        history.push(EditorSnapshot {
+            cursor_pos: 6,
+            selection: None,
+            sequence: vec![A, T, G, T, A, G],
+        });
+
+        assert_eq!(history.snapshots.len(), 3);
+        assert_eq!(history.snapshots[0], EditorSnapshot::default());
+        assert_eq!(
+            history.snapshots[1],
+            EditorSnapshot {
+                cursor_pos: 4,
+                selection: None,
+                sequence: vec![A, T, G, C],
+            }
+        );
+        assert_eq!(
+            history.snapshots[2],
+            EditorSnapshot {
+                cursor_pos: 6,
+                selection: None,
+                sequence: vec![A, T, G, T, A, G],
+            }
+        );
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,15 +5,17 @@
 
 use parking_lot::RwLock;
 
-mod state;
-use state::{CursorMovement, SelectionMovement, SequenceState};
+mod editor;
+use editor::{CursorMovement, Editor, SelectionMovement};
+
+mod history;
 
 mod shared;
 use shared::{CursorData, SequenceData, SequenceItem};
 
 fn main() {
     tauri::Builder::default()
-        .manage(RwLock::new(SequenceState::default()))
+        .manage(RwLock::new(Editor::default()))
         .invoke_handler(tauri::generate_handler![
             initialize_editor,
             calculate_sequence_data,
@@ -34,113 +36,122 @@ fn main() {
             expand_selection_left,
             expand_selection_right,
             get_selected_sequence,
+            undo,
+            redo,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }
 
 #[tauri::command]
-fn initialize_editor(state: tauri::State<RwLock<SequenceState>>, sequence: String) {
+fn initialize_editor(state: tauri::State<RwLock<Editor>>, sequence: String) {
     let mut state = state.write();
     state.reset();
     state.insert_all(sequence);
 }
 
 #[tauri::command]
-fn sequence_insert(state: tauri::State<RwLock<SequenceState>>, letter: char) {
+fn sequence_insert(state: tauri::State<RwLock<Editor>>, letter: char) {
     state.write().insert(letter);
 }
 
 #[tauri::command]
-fn sequence_insert_all(state: tauri::State<RwLock<SequenceState>>, text: String) {
+fn sequence_insert_all(state: tauri::State<RwLock<Editor>>, text: String) {
     let text_without_whitespace = text.chars().filter(|c| !c.is_whitespace()).collect();
     state.write().insert_all(text_without_whitespace);
 }
 
 #[tauri::command]
-fn sequence_delete(state: tauri::State<RwLock<SequenceState>>) {
+fn sequence_delete(state: tauri::State<RwLock<Editor>>) {
     state.write().delete();
 }
 
 #[tauri::command]
-fn sequence_delete_next(state: tauri::State<RwLock<SequenceState>>) {
+fn sequence_delete_next(state: tauri::State<RwLock<Editor>>) {
     state.write().delete_next();
 }
 
 #[tauri::command]
-fn move_cursor(state: tauri::State<RwLock<SequenceState>>, index: usize) {
+fn move_cursor(state: tauri::State<RwLock<Editor>>, index: usize) {
     state.write().move_cursor(CursorMovement::To(index));
 }
 
 #[tauri::command]
-fn move_cursor_left(state: tauri::State<RwLock<SequenceState>>) {
+fn move_cursor_left(state: tauri::State<RwLock<Editor>>) {
     state.write().move_cursor(CursorMovement::By(-1));
 }
 
 #[tauri::command]
-fn move_cursor_right(state: tauri::State<RwLock<SequenceState>>) {
+fn move_cursor_right(state: tauri::State<RwLock<Editor>>) {
     state.write().move_cursor(CursorMovement::By(1));
 }
 
 #[tauri::command]
-fn move_cursor_to_start(state: tauri::State<RwLock<SequenceState>>) {
+fn move_cursor_to_start(state: tauri::State<RwLock<Editor>>) {
     state.write().move_cursor(CursorMovement::Start);
 }
 
 #[tauri::command]
-fn move_cursor_to_end(state: tauri::State<RwLock<SequenceState>>) {
+fn move_cursor_to_end(state: tauri::State<RwLock<Editor>>) {
     state.write().move_cursor(CursorMovement::End);
 }
 
 #[tauri::command]
-fn move_cursor_to_codon_start(state: tauri::State<RwLock<SequenceState>>) {
+fn move_cursor_to_codon_start(state: tauri::State<RwLock<Editor>>) {
     state.write().move_cursor(CursorMovement::CodonStart);
 }
 
 #[tauri::command]
-fn move_cursor_to_codon_end(state: tauri::State<RwLock<SequenceState>>) {
+fn move_cursor_to_codon_end(state: tauri::State<RwLock<Editor>>) {
     state.write().move_cursor(CursorMovement::CodonEnd);
 }
 
 #[tauri::command]
-fn set_selection(state: tauri::State<RwLock<SequenceState>>, start: usize, end: usize) {
+fn set_selection(state: tauri::State<RwLock<Editor>>, start: usize, end: usize) {
     state
         .write()
         .move_selection(SelectionMovement::Set { start, end });
 }
 
 #[tauri::command]
-fn set_selection_all(state: tauri::State<RwLock<SequenceState>>) {
+fn set_selection_all(state: tauri::State<RwLock<Editor>>) {
     state.write().move_selection(SelectionMovement::All);
 }
 
 #[tauri::command]
-fn reset_selection(state: tauri::State<RwLock<SequenceState>>) {
+fn reset_selection(state: tauri::State<RwLock<Editor>>) {
     state.write().move_selection(SelectionMovement::Reset);
 }
 
 #[tauri::command]
-fn expand_selection_left(state: tauri::State<RwLock<SequenceState>>) {
+fn expand_selection_left(state: tauri::State<RwLock<Editor>>) {
     state
         .write()
         .move_selection(SelectionMovement::ExpandBy(-1));
 }
 
 #[tauri::command]
-fn expand_selection_right(state: tauri::State<RwLock<SequenceState>>) {
+fn expand_selection_right(state: tauri::State<RwLock<Editor>>) {
     state.write().move_selection(SelectionMovement::ExpandBy(1));
 }
 
 #[tauri::command]
-fn get_selected_sequence(state: tauri::State<RwLock<SequenceState>>) -> String {
+fn get_selected_sequence(state: tauri::State<RwLock<Editor>>) -> String {
     state.read().get_selected_sequence()
 }
 
 #[tauri::command]
-fn calculate_sequence_data(
-    state: tauri::State<RwLock<SequenceState>>,
-    force: bool,
-) -> SequenceData {
+fn undo(state: tauri::State<RwLock<Editor>>) {
+    state.write().undo();
+}
+
+#[tauri::command]
+fn redo(state: tauri::State<RwLock<Editor>>) {
+    state.write().redo();
+}
+
+#[tauri::command]
+fn calculate_sequence_data(state: tauri::State<RwLock<Editor>>, force: bool) -> SequenceData {
     let data = {
         if force || state.read().sequence_dirty {
             let mut data: Vec<SequenceItem> = Vec::with_capacity(state.read().codons.len());

--- a/src-tauri/src/shared/sequence_data.rs
+++ b/src-tauri/src/shared/sequence_data.rs
@@ -20,8 +20,8 @@ pub struct SelectionData {
     pub end: usize,
 }
 
-impl From<&crate::state::Selection> for SelectionData {
-    fn from(selection: &crate::state::Selection) -> Self {
+impl From<&crate::editor::Selection> for SelectionData {
+    fn from(selection: &crate::editor::Selection) -> Self {
         SelectionData {
             start: selection.start,
             end: selection.end,

--- a/src/components/workspace/editor/Editor.js
+++ b/src/components/workspace/editor/Editor.js
@@ -89,7 +89,6 @@ export default styled(Editor)`
         width: 100%;
         height: 100%;
         overflow: auto;
-        padding: .5rem;
 
         &:focus {
             outline: none;

--- a/src/components/workspace/renderers/NextRenderer.js
+++ b/src/components/workspace/renderers/NextRenderer.js
@@ -323,6 +323,7 @@ export default styled(NextRenderer)`
     font-size: 14pt;
     cursor: text;
     width: 100%;
+    padding: 1rem;
 
     & .cursor-wrapper {
         margin-top: 0.45rem;


### PR DESCRIPTION
This PR implements basic undo/redo functionality.

- [x] Backend
  - [x] Implement history structure
  - [x] Integrate history into editor
  - [x] Write tests
- [x] Frontend
  - [x] Add keybinds and RPC calls

~Even though the functionality is tested, it still feels a bit wonky at times. Gotta look into that.~
As far as I can tell that's fixed now.

## Misc

- Fixes some selection issues by moving padding from `Editor` to `NextRenderer`
- Refactors the Editor code quite a bit to be more cleanly separated between private and public API

The current implementation of the history is snapshot-based and wastes a lot of memory (well, in terms of absolute memory it's not a lot, but in theory.. it could be smaller). I chose to do it that way because it makes the implementation straightforward and easily testable, with minimal changes to the editor code itself. For now, I'm more concerned with base functionality than with memory efficiency and perfect data structures.

Closes #13